### PR TITLE
Add fields to package.json required for npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "phone-format",
   "private": true,
   "version": "1.0.1",
+  "main": "dist/phone-format-exports.js",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-autowrap": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "phone-format",
   "private": true,
+  "version": "1.0.1",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-autowrap": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "phone-format",
   "private": true,
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Even as an unpublished project, the `name` and `version` fields are required to install from github. With this fix, anyone can now `npm install albeebe/phoneformat.js`. And if you do decide to publish, the `phone-format` name is currently available as well. Merging this will be safe, though the version should be updated before publishing to reflect your more recent work (if you do publish).